### PR TITLE
Remove implication that state/props are inherent arguments.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,9 +46,9 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
       ...memoizeOptions
     )
 
-    const selector = (state, props, ...args) => {
+    const selector = (...args) => {
       const params = dependencies.map(
-        dependency => dependency(state, props, ...args)
+        dependency => dependency(...args)
       )
       return memoizedResultFunc(...params)
     }


### PR DESCRIPTION
It feels very React-specific and unnecessary to label those arguments, so why not drop it?