### PR TITLE
Use loose mode for modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/rackt/reselect/issues"
   },
   "scripts": {
-    "compile": "babel -d lib/ src/",
+    "compile": "babel --loose es6.modules -d lib/ src/",
     "lint": "eslint src test",
     "prepublish": "npm run compile",
     "test": "NODE_ENV=test mocha --compilers js:babel/register --recursive",


### PR DESCRIPTION
Support IE8

Changing to `exports.__esModule = true` manually in the imported code makes it work. Without it, `Object.defineProperty` is used.

```js
Object.defineProperty(exports, '__esModule', {
  value: true
});
```
This is a no-op in core-js for IE8, so the `import`-transform in babel doesn't work.

And yes, I know IE8 isn't supported by MS anymore, but this is a small change.

Workaround for now is to use `const { createSelector } = require('reselect');`, but I don't want that :laughing: 
