### PR TITLE
Fix issue with defaultMemoize and multiple arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export function defaultMemoize(func, equalityCheck = defaultEqualityCheck) {
   let lastArgs = null
   let lastResult = null
   return (...args) => {
-    if (lastArgs !== null &&
+    if (lastArgs !== null && lastArgs.length === args.length &&
         args.every((value, index) => equalityCheck(value, lastArgs[index]))) {
       return lastResult
     }

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -187,6 +187,11 @@ suite('selector', () => {
     assert.equal(memoized(o2), 2)
     assert.equal(called, 2)
   })
+  test('exported memoize with multiple arguments', () => {
+    const memoized = defaultMemoize((...args) => args.reduce((sum, value) => sum + value, 0))
+    assert.equal(memoized(1, 2), 3)
+    assert.equal(memoized(1), 1)
+  })
   test('exported memoize with valueEquals override', () => { 
     // a rather absurd equals operation we can verify in tests
     let called = 0


### PR DESCRIPTION
Noticed an issue with `defaultMemoize` when you pass in an ordered subset of the memoized arguments, it will incorrectly returned the memoized value.

See test for an example (it fails without the argument length check).